### PR TITLE
Temp workaround for game crashes

### DIFF
--- a/src/main/java/com/jarhax/eyespy/impl/info/VanillaBlockInfoProvider.java
+++ b/src/main/java/com/jarhax/eyespy/impl/info/VanillaBlockInfoProvider.java
@@ -64,7 +64,12 @@ public class VanillaBlockInfoProvider implements InfoProvider<BlockContext> {
                                     continue outer;
                                 }
                             }
-                            stacks.add(stack);
+                            // Crash workaround by setting Durability of broken items to 1.0 and removing any Metadata
+                            // TODO Find actual fix :)
+                            ItemStack safeStack = stack.withMetadata(null)
+                                    .withDurability(stack.getMaxDurability() > 0 ? Math.max(1.0, stack.getDurability()) : stack.getDurability());
+
+                            stacks.add(safeStack);
                         }
                         yield new ItemGridValue(s, stacks);
                     }

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "Group": "JarHax",
     "Name": "EyeSpy",
-    "Version": "2026.1.13-35872",
+    "Version": "2026.1.14-44499",
     "Description": "",
     "Authors": [
         {


### PR DESCRIPTION
The game is currently crashing when trying to preview chests with broken items or crates with captured animals in them.
This is mainly meant to be a temporary fix, but at least the items are displayed without crashing for now.

For broken items it seems like that the only difference to healthy items is the durability.
The temp fix sets the durability of broken items which have a maxDurability to 1.0 and adds them to the stack.

For the animal crates the issue seems to be the Metadata that is attached to it after catching an animal. (I assume it is used to change the icon of a full crate on the clientside as the itemId stays the same)
The temp fix sets the metadata of items to null before pushing it to the stack.

<img width="552" height="163" alt="2026-01-14-133827_hyprshot" src="https://github.com/user-attachments/assets/857f1d93-beaf-4beb-af9d-ad32b4bddc3c" />

<img width="214" height="112" alt="2026-01-14-133833_hyprshot" src="https://github.com/user-attachments/assets/518b4731-1308-4227-98c2-f0463b59a340" />

