### PR TITLE
Fix crash on teleporter use

### DIFF
--- a/src/main/java/com/jarhax/eyespy/api/context/BlockContext.java
+++ b/src/main/java/com/jarhax/eyespy/api/context/BlockContext.java
@@ -2,17 +2,20 @@ package com.jarhax.eyespy.api.context;
 
 import com.hypixel.hytale.component.ArchetypeChunk;
 import com.hypixel.hytale.component.CommandBuffer;
+import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.math.util.ChunkUtil;
 import com.hypixel.hytale.math.vector.Vector3i;
-import com.hypixel.hytale.protocol.BlockPosition;
 import com.hypixel.hytale.server.core.asset.type.blocktype.config.BlockType;
-import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.chunk.WorldChunk;
 import com.hypixel.hytale.server.core.universe.world.meta.BlockState;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.core.util.FillerBlockUtil;
 import com.hypixel.hytale.server.core.util.TargetUtil;
+import org.checkerframework.checker.nullness.compatqual.NonNullDecl;
 
 import javax.annotation.Nullable;
 
@@ -23,7 +26,7 @@ public class BlockContext extends Context {
     private final Vector3i targetPos;
     private final Vector3i offsetPos;
 
-    public BlockContext(float delta, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer, Player observer, WorldChunk chunk, Vector3i targetPos, Vector3i offsetPos, BlockType block, BlockState state) {
+    public BlockContext(float delta, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer, PlayerRef observer, WorldChunk chunk, Vector3i targetPos, Vector3i offsetPos, BlockType block, BlockState state) {
         super(delta, index, archetypeChunk, store, commandBuffer, observer, chunk);
         this.targetPos = targetPos;
         this.offsetPos = offsetPos;
@@ -49,20 +52,49 @@ public class BlockContext extends Context {
     }
 
     @Nullable
-    public static BlockContext create(Player player, float dt, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer) {
-        final TransformComponent transform = archetypeChunk.getComponent(index, TransformComponent.getComponentType());
-        if (transform != null) {
-            final WorldChunk chunk = transform.getChunk();
-            if (chunk != null) {
-                final Vector3i targetBlockPos = TargetUtil.getTargetBlock(archetypeChunk.getReferenceTo(index), 5, commandBuffer);
-                if (targetBlockPos != null) {
-                    final BlockPosition pos = player.getWorld().getBaseBlock(new BlockPosition(targetBlockPos.x, targetBlockPos.y, targetBlockPos.z));
-                    final BlockType block = chunk.getBlockType(pos.x, pos.y, pos.z);
-                    final BlockState state = chunk.getState(pos.x, pos.y, pos.z);
-                    return new BlockContext(dt, index, archetypeChunk, store, commandBuffer, player, chunk, targetBlockPos, new Vector3i(pos.x, pos.y, pos.z), block, state);
-                }
+    public static BlockContext create(PlayerRef player, float dt, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer) {
+        Ref<EntityStore> playerRef = player.getReference();
+        if (playerRef == null) {
+            return null;
+        }
+        Store<EntityStore> playerStore = playerRef.getStore();
+        TransformComponent transform = playerStore.getComponent(playerRef, TransformComponent.getComponentType());
+        World world = store.getExternalData().getWorld();
+        final Vector3i targetBlockPos = TargetUtil.getTargetBlock(archetypeChunk.getReferenceTo(index), 5, commandBuffer);
+        if (transform != null && targetBlockPos != null) {
+            int x = targetBlockPos.x;
+            int y = targetBlockPos.y;
+            int z = targetBlockPos.z;
+
+            long chunkIndex = ChunkUtil.indexChunkFromBlock(x, z);
+            WorldChunk chunk = world.getChunkIfLoaded(chunkIndex);
+            if (chunk == null) {
+                return null;
             }
+
+            Vector3i basePos = resolveBaseBlock(chunk, x, y, z);
+
+            long baseChunkIndex = ChunkUtil.indexChunkFromBlock(basePos.x, basePos.z);
+            WorldChunk baseChunk = baseChunkIndex == chunkIndex ? chunk : world.getChunkIfLoaded(baseChunkIndex);
+
+            if (baseChunk == null) {
+                return null;
+            }
+
+            BlockType block = baseChunk.getBlockType(basePos.x, basePos.y, basePos.z);
+            BlockState state = baseChunk.getState(basePos.x, basePos.y, basePos.z);
+
+            return new BlockContext(dt, index, archetypeChunk, store, commandBuffer, player, baseChunk, targetBlockPos, basePos, block, state);
         }
         return null;
+    }
+
+    public static Vector3i resolveBaseBlock(WorldChunk chunk, int x, int y, int z) {
+        int filler = chunk.getFiller(x, y, z);
+        if (filler == 0) {
+            return new Vector3i(x, y, z);
+        }
+
+        return new Vector3i(x - FillerBlockUtil.unpackX(filler), y - FillerBlockUtil.unpackY(filler), z - FillerBlockUtil.unpackZ(filler));
     }
 }

--- a/src/main/java/com/jarhax/eyespy/api/context/Context.java
+++ b/src/main/java/com/jarhax/eyespy/api/context/Context.java
@@ -3,7 +3,7 @@ package com.jarhax.eyespy.api.context;
 import com.hypixel.hytale.component.ArchetypeChunk;
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Store;
-import com.hypixel.hytale.server.core.entity.entities.Player;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.chunk.WorldChunk;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 
@@ -15,10 +15,10 @@ public class Context {
     private final Store<EntityStore> store;
     private final CommandBuffer<EntityStore> commandBuffer;
 
-    private final Player observer;
+    private final PlayerRef observer;
     private final WorldChunk chunk;
 
-    public Context(float delta, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer, Player observer, WorldChunk chunk) {
+    public Context(float delta, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer, PlayerRef observer, WorldChunk chunk) {
         this.delta = delta;
         this.index = index;
         this.archetypeChunk = archetypeChunk;
@@ -44,7 +44,7 @@ public class Context {
         return store;
     }
 
-    public Player getObserver() {
+    public PlayerRef getObserver() {
         return observer;
     }
 
@@ -52,7 +52,7 @@ public class Context {
         return commandBuffer;
     }
 
-    public Player observer() {
+    public PlayerRef observer() {
         return this.observer;
     }
 

--- a/src/main/java/com/jarhax/eyespy/api/context/EntityContext.java
+++ b/src/main/java/com/jarhax/eyespy/api/context/EntityContext.java
@@ -4,8 +4,11 @@ import com.hypixel.hytale.component.ArchetypeChunk;
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
-import com.hypixel.hytale.server.core.entity.entities.Player;
+import com.hypixel.hytale.math.util.ChunkUtil;
+import com.hypixel.hytale.math.vector.Vector3d;
 import com.hypixel.hytale.server.core.modules.entity.component.TransformComponent;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.chunk.WorldChunk;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.hypixel.hytale.server.core.util.TargetUtil;
@@ -16,7 +19,7 @@ public class EntityContext extends Context {
 
     private final Ref<EntityStore> entity;
 
-    public EntityContext(float delta, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer, Player observer, WorldChunk chunk, Ref<EntityStore> entity) {
+    public EntityContext(float delta, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer, PlayerRef observer, WorldChunk chunk, Ref<EntityStore> entity) {
         super(delta, index, archetypeChunk, store, commandBuffer, observer, chunk);
         this.entity = entity;
     }
@@ -26,12 +29,26 @@ public class EntityContext extends Context {
     }
 
     @Nullable
-    public static EntityContext create(Player player, float dt, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer) {
-
+    public static EntityContext create(PlayerRef player, float dt, int index, ArchetypeChunk<EntityStore> archetypeChunk, Store<EntityStore> store, CommandBuffer<EntityStore> commandBuffer) {
+        Ref<EntityStore> playerRef = player.getReference();
+        if (playerRef == null) {
+            return null;
+        }
+        Store<EntityStore> playerStore = playerRef.getStore();
+        World world = store.getExternalData().getWorld();
         final Ref<EntityStore> targetEntity = TargetUtil.getTargetEntity(archetypeChunk.getReferenceTo(index), commandBuffer);
-        final TransformComponent transform = archetypeChunk.getComponent(index, TransformComponent.getComponentType());
-        if (transform != null && targetEntity != null) {
-            final WorldChunk chunk = transform.getChunk();
+        TransformComponent transform = playerStore.getComponent(playerRef, TransformComponent.getComponentType());
+
+        if (transform == null) {
+            return null;
+        }
+        Vector3d position = transform.getPosition();
+
+        if (targetEntity != null) {
+            int X = (int) Math.floor(position.x);
+            int Z = (int) Math.floor(position.z);
+            long chunkIndex = ChunkUtil.indexChunkFromBlock(X, Z);
+            WorldChunk chunk = world.getChunkIfLoaded(chunkIndex);
             return new EntityContext(dt, index, archetypeChunk, store, commandBuffer, player, chunk, targetEntity);
         }
 

--- a/src/main/java/com/jarhax/eyespy/impl/hud/EyeSpyHud.java
+++ b/src/main/java/com/jarhax/eyespy/impl/hud/EyeSpyHud.java
@@ -1,14 +1,11 @@
 package com.jarhax.eyespy.impl.hud;
 
-import com.hypixel.hytale.component.ArchetypeChunk;
-import com.hypixel.hytale.component.CommandBuffer;
-import com.hypixel.hytale.component.Holder;
-import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.component.*;
 import com.hypixel.hytale.server.core.entity.EntityUtils;
-import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.entity.entities.player.hud.CustomUIHud;
 import com.hypixel.hytale.server.core.ui.builder.UICommandBuilder;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.World;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import com.jarhax.eyespy.api.context.BlockContext;
 import com.jarhax.eyespy.api.context.EntityContext;
@@ -50,17 +47,17 @@ public class EyeSpyHud extends CustomUIHud {
 
     public void updateHud(float dt, int index, @Nonnull ArchetypeChunk<EntityStore> archetypeChunk, @Nonnull Store<EntityStore> store, @Nonnull CommandBuffer<EntityStore> commandBuffer) {
         this.info = new InfoBuilder();
-        final Holder<EntityStore> holder = EntityUtils.toHolder(index, archetypeChunk);
-        final Player player = holder.getComponent(Player.getComponentType());
+        PlayerRef playerRef = archetypeChunk.getComponent(index, PlayerRef.getComponentType());
+        World world = store.getExternalData().getWorld();
 
-        if (player != null && player.getWorld() != null) {
-            this.entityContext = EntityContext.create(player, dt, index, archetypeChunk, store, commandBuffer);
+        if (playerRef != null && world != null) {
+            this.entityContext = EntityContext.create(playerRef, dt, index, archetypeChunk, store, commandBuffer);
             if (this.entityContext != null) {
                 for (InfoProvider<EntityContext> provider : entityInfoProviders) {
                     provider.updateDescription(this.entityContext, this.info);
                 }
             } else {
-                this.blockContext = BlockContext.create(player, dt, index, archetypeChunk, store, commandBuffer);
+                this.blockContext = BlockContext.create(playerRef, dt, index, archetypeChunk, store, commandBuffer);
                 if (this.blockContext != null) {
                     for (InfoProvider<BlockContext> provider : blockInfoProviders) {
                         provider.updateDescription(this.blockContext, this.info);

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "Group": "JarHax",
     "Name": "EyeSpy",
-    "Version": "2026.1.14-44499",
+    "Version": "2026.1.17-45102",
     "Description": "",
     "Authors": [
         {


### PR DESCRIPTION
I am quite confident that this should fix the teleporter crash, unless I got very lucky during testing and didn't encounter a crash again.

The main difference is that we are now using PlayerRef and getting the world through the store.
The transform component also now uses the playerStore.
Since we are now using the world to get the chunks we got access to quite a few more ways to obtain them, which seems to be a safer way to do so. The `.getChunkIfLoaded()` method seems to be working well for this.

<img width="609" height="195" alt="image" src="https://github.com/user-attachments/assets/3ed128fd-cff1-4e29-84a4-7c9fa1de9bbb" />

I had to reimplement some extra code to find the base block as we don't have access to `.getBaseBlock()` anymore this way.

I of course hope that this doesn't break other things, but I haven't encountered any new issues during my testing. Feel free to adjust this PR if something is wrong or off as I've gotten to this point mainly through trial and error :D