### PR TITLE
Fix invisible NPC markers getting displayed

### DIFF
--- a/src/main/java/com/jarhax/eyespy/impl/info/VanillaEntityInfoProvider.java
+++ b/src/main/java/com/jarhax/eyespy/impl/info/VanillaEntityInfoProvider.java
@@ -3,6 +3,7 @@ package com.jarhax.eyespy.impl.info;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.modules.entity.component.DisplayNameComponent;
+import com.hypixel.hytale.server.core.modules.entity.component.ModelComponent;
 import com.hypixel.hytale.server.core.modules.entitystats.EntityStatMap;
 import com.hypixel.hytale.server.core.modules.entitystats.EntityStatValue;
 import com.hypixel.hytale.server.core.modules.entitystats.asset.EntityStatType;
@@ -18,6 +19,14 @@ public class VanillaEntityInfoProvider implements InfoProvider<EntityContext> {
     public void updateDescription(EntityContext context, InfoBuilder infoBuilder) {
 
         final Store<EntityStore> store = context.getStore();
+
+        //Get Model Component and Asset ID to filter out invisible path marker entities
+        ModelComponent modelComponent = store.getComponent(context.entity(), ModelComponent.getComponentType());
+        String modelAssetId = modelComponent.getModel().getModelAssetId();
+        if (modelAssetId.equals("NPC_Path_Marker")) {
+            return;
+        }
+
         final DisplayNameComponent displayName = store.getComponent(context.entity(), DisplayNameComponent.getComponentType());
         if (displayName != null) {
             infoBuilder.set("Header", s -> new LabelValue(s, displayName.getDisplayName(), 24));


### PR DESCRIPTION
Currently invisible entities are getting displayed.
<img width="1022" height="87" alt="2026-01-17-163058_hyprshot" src="https://github.com/user-attachments/assets/e0a06522-7320-45c4-a49f-74104b82a915" />

Turns out they are NPC Path Markers (at least the ones I found so far, should there be others then they can be easily added)
<img width="843" height="245" alt="2026-01-17-163229_hyprshot" src="https://github.com/user-attachments/assets/10d79952-eddb-495e-990e-eb7b9bdc3634" />

Simplest solution I found for this was checking the `modelAssetId` and returning early on unwanted ones.