### PR TITLE
Use official maven hytale repo & simplify processResources logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,28 +57,14 @@ if (!serverRunDir.exists()) {
     serverRunDir.mkdirs()
 }
 
-// Updates the manifest.json file with the latest properties defined in the
-// build.properties file. Currently we update the version and if packs are
-// included with the plugin.
-tasks.register('updatePluginManifest') {
-    def manifestFile = file('src/main/resources/manifest.json')
-    doLast {
-        if (!manifestFile.exists()) {
-            throw new GradleException("Could not find manifest.json at ${manifestFile.path}!")
-        }
-        def manifestJson = new groovy.json.JsonSlurper().parseText(manifestFile.text)
-        manifestJson.Version = version
-        manifestJson.IncludesAssetPack = includes_pack.toBoolean()
-        manifestFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(manifestJson))
-    }
-}
-
-// Makes sure the plugin manifest is up to date.
-tasks.named('processResources') {
-    dependsOn 'updatePluginManifest'
-}
-
 processResources {
+    filesMatching("manifest.json") {
+        expand(
+                version: project.version,
+                includeAssetPack: includes_pack.toBoolean(),
+        )
+    }
+
     doLast {
         def jsonMinifyStart = System.currentTimeMillis()
         def jsonMinified = 0

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ javadoc {
 }
 
 repositories {
+    maven {
+        url 'https://maven.hytale.com/release/'
+    }
+
     exclusiveContent {
         forRepository {
             maven {
@@ -43,8 +47,8 @@ repositories {
 // compile against their code. This requires you to have Hytale installed using
 // the official launcher for now.
 dependencies {
-    implementation(files("$hytaleHome/install/$patchline/package/game/latest/Server/HytaleServer.jar"))
-    compileOnly("curse.maven:mhud-1423634:7484171")
+    compileOnly "com.hypixel.hytale:Server:latest.release"
+    compileOnly "curse.maven:mhud-1423634:7484171"
 }
 
 // Create the working directory to run the server if it does not already exist.

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "Group": "JarHax",
     "Name": "EyeSpy",
-    "Version": "2026.2.2-948",
+    "Version": "${version}",
     "Description": "",
     "Authors": [
         {
@@ -24,5 +24,5 @@
     },
     "DisabledByDefault": false,
     "Main": "com.jarhax.eyespy.EyeSpy",
-    "IncludesAssetPack": true
+    "IncludesAssetPack": ${includeAssetPack}
 }


### PR DESCRIPTION
Hytale server has an official maven repository that is probably preferable to use over a jar file stored on the author's computer.

I've also simplified the processResources logic, gradle can replace variables in the resources folder via the expand method.

The json minification is interesting. I didn't touch it because I'm not sure why it's there tbh. Curseforge is very lenient with mod sizes, and the minification of the json would save mere bytes at most, with no performance benefit. Perhaps it is a remnant from mods, seeing as you're minifying mcmeta files too - does it need to be in the mod?